### PR TITLE
PLAT-4232 - changing mergetime to always be UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ The action packages, signs the Lambda functions, and uploads the application to 
 It adds the following metadata to the S3 object:
 
 - committag - The tag of the git commit (if present), this falls back to a shortened commit has.
-- repository - The git repository where the file was loaded from
+- repository - The git repository where the file was loaded from.
 - commitmessage - The first 50 characters of the git commit message, trimmed to the following regex: `tr -dc '[:alnum:]- '`
 - commitsha - The full git commitsha of the git commit.
+- mergetime - Time in UTC when git merge happend.
+- skipcanary - 0 or 1 for skipcanary.
 
 ## Action Inputs
 

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -23,8 +23,8 @@ fi
 GIT_TAG=$(git describe --tags --first-parent --always)
 # Cleaning the commit message to remove special characters
 COMMIT_MSG=$(echo $COMMIT_MESSAGE | tr '\n' ' ' | tr -dc '[:alnum:]- ' | cut -c1-50)
-# Gets merge time to main
-MERGE_TIME=$(git log -1 --format=%cd --date=format:'%Y-%m-%d %H:%M:%S')
+# Gets merge time to main - displaying it in UTC timezone
+MERGE_TIME=$(TZ=UTC0 git log -1 --format=%cd --date=format:'%Y-%m-%d %H:%M:%S')
 
 # Sanitise commit message and search for canary deployment instructions
 MSG=$(echo $COMMIT_MESSAGE | tr '\n' ' ' | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
PLAT-4232 - changing mergetime to always be UTC

The DATE below shows as "+0100" and "+0000"
```
commit 7c4069ed969c856HEAD -> PLAT-4232-mergetime, origin/PLAT-4232-mergetime)
Author: Andy Goldschmidt 
Date:   Wed Apr 17 11:24:09 2024 +0100

commit 1bf704ccba8eaebea0bd44 (tag: v3.5-beta, tag: v3.5, origin/main, origin/HEAD, main)
Merge: 11b9b34 4ed4c80
Author: Monjurul Haque
Date:   Tue Jan 16 12:14:26 2024 +0000
```
$ git log --format=%cd --date=format:'%Y-%m-%d %H:%M:%S'
2024-04-17 11:24:09             <- this is actually in BST
2024-01-16 12:14:26             <- this is actually in UTC
2024-01-12 14:24:56             <- this is actually in UTC

$ TZ=UTC0  git log --format=%cd --date=format-local:'%Y-%m-%d %H:%M:%S'
2024-04-17 10:24:09             <- this is actually in UTC
2024-01-16 12:14:26             <- this is actually in UTC
2024-01-12 14:24:56             <- this is actually in UTC