### PR TITLE
PSREDEV-527: enable escape hatch for for different GHA triggers

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,5 @@ runs:
         ARTIFACT_BUCKET: ${{ inputs.artifact-bucket-name }}
         SIGNING_PROFILE: ${{ inputs.signing-profile-name }}
         TEMPLATE_FILE: ${{ inputs.template-file }}
-        COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       run: ${{ github.action_path }}/scripts/upload.sh
       shell: bash

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -2,6 +2,9 @@
 
 set -eu
 
+# This gets the commit message of whatever branch is in use
+COMMIT_MESSAGE=$(git show -s --format=%s)
+
 echo "Parsing resources to be signed"
 RESOURCES="$(yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::Function" or .Type == "AWS::Serverless::LayerVersion") | path | .[1]' "$TEMPLATE_FILE" | xargs)"
 read -ra LIST <<< "$RESOURCES"


### PR DESCRIPTION
- Changed command to get the latest commit message
- This enables developers to use skip-canary with `workflow_dispatch`, where previously the commit message could only be accessed in `push` events
- Tests below show commit message persisting in metadata and [skip canary] commit running CodeDeploy deployment
![Screenshot 2024-05-23 at 17 30 48](https://github.com/govuk-one-login/devplatform-upload-action/assets/93530090/6ee560d3-d39a-401c-9a20-f54452be551f)

<img width="1078" alt="Screenshot 2024-05-23 at 14 31 43" src="https://github.com/govuk-one-login/devplatform-upload-action/assets/93530090/8bcbb0d5-5c13-4004-9715-abd5a7851e22">
