### PR TITLE
PSREDEV-1829: Address linting issues

### DIFF
--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -11,8 +11,7 @@ read -ra LIST <<< "$RESOURCES"
 PROFILES=("${LIST[@]/%/="$SIGNING_PROFILE"}")
 
 echo "Packaging SAM app"
-if [ "${#PROFILES[@]}" -eq 0 ]
-then
+if [ "${#PROFILES[@]}" -eq 0 ]; then
   echo "No resources that require signing found"
   sam package --s3-bucket="$ARTIFACT_BUCKET" --template-file="$TEMPLATE_FILE" --output-template-file=cf-template.yaml
 else
@@ -29,17 +28,18 @@ MERGE_TIME=$(TZ=UTC0 git log -1 --format=%cd --date=format-local:'%Y-%m-%d %H:%M
 # Sanitise commit message and search for canary deployment instructions
 MSG=$(echo "$COMMIT_MESSAGE" | tr '\n' ' ' | tr '[:upper:]' '[:lower:]')
 if [[ $MSG =~ \[(skip canary|no canary|canary skip)\] ]]; then
-    SKIP_CANARY_DEPLOYMENT=1
+  SKIP_CANARY_DEPLOYMENT=1
 else
-    SKIP_CANARY_DEPLOYMENT=0
+  SKIP_CANARY_DEPLOYMENT=0
 fi
 
 echo "Writing Lambda provenance"
-yq '.Resources.* | select(has("Type") and has("Properties.CodeUri") and .Type == "AWS::Serverless::Function") | .Properties.CodeUri' cf-template.yaml \
-    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG,commitauthor='$GITHUB_ACTOR',release=$VERSION_NUMBER"
+yq '.Resources.* | select(has("Type") and has("Properties.CodeUri") and .Type == "AWS::Serverless::Function") | .Properties.CodeUri' cf-template.yaml |
+  xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG,commitauthor='$GITHUB_ACTOR',release=$VERSION_NUMBER"
+
 echo "Writing Lambda Layer provenance"
-yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::LayerVersion") | .Properties.ContentUri' cf-template.yaml \
-    | xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG,commitauthor='$GITHUB_ACTOR',release=$VERSION_NUMBER"
+yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::LayerVersion") | .Properties.ContentUri' cf-template.yaml |
+  xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG,commitauthor='$GITHUB_ACTOR',release=$VERSION_NUMBER"
 
 echo "Zipping the CloudFormation template"
 zip template.zip cf-template.yaml

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -22,13 +22,13 @@ fi
 # This only gets set if there is a tag on the current commit.
 GIT_TAG=$(git describe --tags --first-parent --always)
 # Cleaning the commit message to remove special characters
-COMMIT_MSG=$(echo $COMMIT_MESSAGE | tr '\n' ' ' | tr -dc '[:alnum:]- ' | cut -c1-50)
+COMMIT_MSG=$(echo "$COMMIT_MESSAGE" | tr '\n' ' ' | tr -dc '[:alnum:]- ' | cut -c1-50)
 # Gets merge time to main - displaying it in UTC timezone
 MERGE_TIME=$(TZ=UTC0 git log -1 --format=%cd --date=format-local:'%Y-%m-%d %H:%M:%S')
 
 # Sanitise commit message and search for canary deployment instructions
-MSG=$(echo $COMMIT_MESSAGE | tr '\n' ' ' | tr '[:upper:]' '[:lower:]')
-if [[ $MSG =~ "[skip canary]" || $MSG =~ "[canary skip]" || $MSG =~ "[no canary]" ]]; then
+MSG=$(echo "$COMMIT_MESSAGE" | tr '\n' ' ' | tr '[:upper:]' '[:lower:]')
+if [[ $MSG =~ \[(skip canary|no canary|canary skip)\] ]]; then
     SKIP_CANARY_DEPLOYMENT=1
 else
     SKIP_CANARY_DEPLOYMENT=0


### PR DESCRIPTION
## Description

This addresses the pre-existing linting/formatting issues before the new pre-merge checks were introduced.

## GitHub Action Releases

We follow [recommended best practices](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions) for releasing new versions of the action.

### Non-breaking Chanages:
Release a new minor or patch version as appropriate. Then, update the base major version release (and any minor versions)
to point to this latest commit. For example, if the latest major release is v2 and you have added a non-breaking feature,
release v2.1.0 and point v2 to the same commit as v2.1.0.

NOTE: Dependabot does not pick up and raise PRs for `PATCH` versions (i.e v3.8.1), please nofity teams in the relevant slack channels.

### Breaking Changes:
Release a new major version as normal following semantic versioning.

## Checklist

- [x] Is my change backwards compatible? **_Please include evidence_**
- [ ] I have tested this and added output to Jira
**_Comment:_**
- [ ] Automated tests added
**_Comment:_**
- [ ] Documentation added ([link]())
**_Comment:_**
- [ ] Delete any new stacks created for this ticket
**_Comment:_**

