### PR TITLE
PSREDEV-2150: Fix lambda provenance metadata not getting set

### DIFF
--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -34,11 +34,11 @@ else
 fi
 
 echo "Writing Lambda provenance"
-yq '.Resources.* | select(has("Type") and has("Properties.CodeUri") and .Type == "AWS::Serverless::Function") | .Properties.CodeUri' cf-template.yaml |
+yq '.Resources.* | select(.Type == "AWS::Serverless::Function" and .Properties | has("CodeUri")) | .Properties.CodeUri' cf-template.yaml |
   xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG,commitauthor='$GITHUB_ACTOR',release=$VERSION_NUMBER"
 
 echo "Writing Lambda Layer provenance"
-yq '.Resources.* | select(has("Type") and .Type == "AWS::Serverless::LayerVersion") | .Properties.ContentUri' cf-template.yaml |
+yq '.Resources.* | select(.Type == "AWS::Serverless::LayerVersion") | .Properties.ContentUri' cf-template.yaml |
   xargs -L1 -I{} aws s3 cp "{}" "{}" --metadata "repository=$GITHUB_REPOSITORY,commitsha=$GITHUB_SHA,committag=$GIT_TAG,commitmessage=$COMMIT_MSG,commitauthor='$GITHUB_ACTOR',release=$VERSION_NUMBER"
 
 echo "Zipping the CloudFormation template"


### PR DESCRIPTION
## Description

**PSREDEV-2150: Fix lambda provenance metadata not getting set**

The current yq query doesn't select any lambdas. Amend it to use the `.Properties | has("CodeUri")` filter and select lambdas with a `CodeUri` property.

Remove the check for `Type` as it is a required property and all CloudFormation resources will have it.

## Checklist

- [x] Is my change backwards compatible? **_Please include evidence_**
- [x] I have tested this and added output to Jira
  **_Comment:_**
- [ ] Automated tests added
  **_Comment:_**
- [ ] Documentation added ([link]())
  **_Comment:_**
- [ ] Delete any new stacks created for this ticket
  **_Comment:_**
