### PR TITLE
PSREDEV-2237: Add metadata flag to indicate healthy artifact

### DIFF
--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -43,6 +43,7 @@ echo "::endgroup::"
 echo "::group::Gathering release metadata"
 
 [[ $COMMIT_MESSAGES =~ \[(skip canary|no canary|canary skip)\] ]] && skip_canary=1
+[[ $COMMIT_MESSAGES =~ \[(close circuit breaker|end circuit breaker)\] ]] && close_circuit_breaker=1
 
 release_metadata=(
   "commitsha=$GITHUB_SHA"                                                    # Head commit SHA
@@ -52,6 +53,7 @@ release_metadata=(
   "commitauthor='$GITHUB_ACTOR'"
   "repository=$GITHUB_REPOSITORY"
   "skipcanary=${skip_canary:-0}"
+  "closecircuitbreaker=${close_circuit_breaker:-0}"
 )
 
 [[ ${VERSION:-} ]] && release_metadata+=(

--- a/scripts/upload.test.sh
+++ b/scripts/upload.test.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 : "${VERSION:=}"
 : "${SKIP_CANARY:=0}"
+: "${CLOSE_CIRCUIT_BREAKER:=0}"
 : "${GITHUB_SHA:=$(git rev-parse HEAD)}"
 : "${GIT_TAG:=$(git describe --tags --first-parent --always)}"
 : "${COMMIT_MESSAGE:=$(git log -1 --format=%s | head -n 1 | cut -c1-50)}"
@@ -31,6 +32,7 @@ expected_metadata=(
   [skipcanary]=$SKIP_CANARY
   [release]=$VERSION
   ["codepipeline-artifact-revision-summary"]=$VERSION
+  [closecircuitbreaker]=$CLOSE_CIRCUIT_BREAKER
 )
 
 function format-error() {


### PR DESCRIPTION
- New artifact metadata closecircuitbreaker to be added from developer's commit
- Added feature to tests

## Description

### Ticket number

[PSREDEV-2237]

## GitHub Action Releases

We
follow [recommended best practices](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions)
for releasing new versions of the action.

### Non-breaking Changes:

Release a new minor or patch version as appropriate. Then, update the base major version release (and any minor
versions) to point to this latest commit. For example, if the latest major release is v2, and you have added a
non-breaking feature, release v2.1.0 and point v2 to the same commit as v2.1.0.

NOTE: Dependabot does not pick up and raise PRs for `PATCH` versions (i.e. v3.8.1), please notify teams in the relevant
Slack channels.

### Breaking Changes:

Release a new major version as normal following semantic versioning.

## Checklist

- [x] Is my change backwards compatible? **_Please include evidence_**
- [] I have tested this and added output to Jira
  **_Comment:_**
- [x] Automated tests added
  **_Comment:_**
- [ ] Documentation added ([link]())
  **_Comment:_**
- [ ] Delete any new stacks created for this ticket
  **_Comment:_**

### Co-authored by


[PSREDEV-2237]: https://govukverify.atlassian.net/browse/PSREDEV-2237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ