### PR TITLE
PSREDEV-2262 | Remove unnecessary token from workflow checkout

### DIFF
--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: govuk-one-login/devplatform-demo-sam-app
-          token: ${{ secrets.LEAD_ENGINEER_GITHUB_TOKEN }}
           path: demo
 
       - name: Build demo SAM app


### PR DESCRIPTION
## Description

The repository being checked out in the `.github/workflows/test-action.yaml` workflow (demo-sam-app) has recently been made public.

This PR removes the `token: ${{ secrets.LEAD_ENGINEER_GITHUB_TOKEN }}` line from the `actions/checkout` step responsible for cloning the demo-sam-app repository.

Authentication via the PAT is no longer required to access the public `demo-sam-app` repository, so the token usage is now not needed and has been removed to simplify the workflow remove secrets where they are unnecessary.

### Ticket number

[PSREDEV-2262]

[PSREDEV-2262]: https://govukverify.atlassian.net/browse/PSREDEV-2262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ