### PR TITLE
fix(PSREDEV-3010): escape single quote characters from commit message

### DIFF
--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -113,3 +113,62 @@ jobs:
           ARTIFACT_PREFIX: ${{ steps.get-branch-name.outputs.pretty-branch-name }}
           ARTIFACT_BUCKET: ${{ vars.ARTIFACT_SOURCE_BUCKET }}
           VERSION: test-${{ github.sha }}
+
+  run-upload-script-tests:
+    name: Test upload script
+    environment: development
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull demo SAM app
+        uses: actions/checkout@v4
+        with:
+          repository: govuk-one-login/devplatform-demo-sam-app
+          path: demo
+
+      - name: Build demo SAM app
+        uses: govuk-one-login/github-actions/sam/build-application@5480cced560e896dea12c47ea33e548a4d093e65
+        with:
+          template: demo/sam-app2/template.yaml
+          source-dir: demo/sam-app2/HelloWorldFunction
+
+      - name: Trim branch name
+        uses: govuk-one-login/github-actions/beautify-branch-name@5480cced560e896dea12c47ea33e548a4d093e65
+        id: get-branch-name
+        with:
+          length-limit: 63
+          verbose: false
+
+      - name: Pull action
+        uses: actions/checkout@v4
+        with:
+          path: upload-action
+
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Run upload script
+        working-directory: upload-action
+        run: scripts/upload.sh
+        shell: bash
+        id: upload-sam-app
+        env:
+          ARTIFACT_BUCKET: ${{ vars.ARTIFACT_SOURCE_BUCKET }}
+          ARTIFACT_PREFIX: ${{ steps.get-branch-name.outputs.pretty-branch-name }}/upload-script-tests
+          HEAD_MESSAGE: Message' with" 'quotes" for" testing'
+          SIGNING_PROFILE: ${{ vars.SIGNING_PROFILE_NAME }}
+          TEMPLATE_FILE: ../.aws-sam/build/template.yaml
+          VERSION: test-${{ github.sha }}
+
+      - name: Check uploaded artifact
+        working-directory: upload-action
+        run: scripts/utility.test.sh
+        shell: bash
+        env:
+          ARTIFACT_BUCKET: ${{ vars.ARTIFACT_SOURCE_BUCKET }}
+          ARTIFACT_PREFIX: ${{ steps.get-branch-name.outputs.pretty-branch-name }}/upload-script-tests
+          COMMIT_MESSAGE: Message' with" 'quotes" for" testing'
+          TEMPLATE_FILE: ${{ steps.upload-sam-app.outputs.template-out-file }}
+          VERSION: test-${{ github.sha }}

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -47,10 +47,10 @@ echo "::group::Gathering release metadata"
 [[ $COMMIT_MESSAGES =~ \[(close circuit breaker|end circuit breaker)\] ]] && close_circuit_breaker=1
 
 release_metadata=(
-  "commitsha=$GITHUB_SHA"                                                    # Head commit SHA
-  "committag=$(git describe --tags --first-parent --always)"                 # Head commit tag or short SHA
-  "commitmessage='$(echo "$HEAD_MESSAGE" | head -n 1 | cut -c1-50)'"         # Shortened head commit subject
-  "mergetime=$(TZ=UTC0 git log -1 --format=%cd --date=format-local:"%F %T")" # Merge to main UTC timestamp
+  "commitsha=$GITHUB_SHA"                                                       # Head commit SHA
+  "committag=$(git describe --tags --first-parent --always)"                    # Head commit tag or short SHA
+  "commitmessage='$(echo "${HEAD_MESSAGE//\'/\\\'}" | head -n 1 | cut -c1-50)'" # Shorten head commit subject and escape '
+  "mergetime=$(TZ=UTC0 git log -1 --format=%cd --date=format-local:"%F %T")"    # Merge to main UTC timestamp
   "commitauthor='$GITHUB_ACTOR'"
   "repository=$GITHUB_REPOSITORY"
   "skipcanary=${skip_canary:-0}"

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -77,7 +77,7 @@ done
 
 echo "::endgroup::"
 
-if [ -n "${SYNTHETICS_DIRECTORY}" ]; then
+if [[ ${SYNTHETICS_DIRECTORY:-} ]]; then
   echo "::group::Uploading Synthetic Canaries"
   echo "» Parsing Synthetic Canaries to be uploaded"
 

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -88,9 +88,9 @@ if [ -n "${SYNTHETICS_DIRECTORY}" ]; then
 
   echo "ℹ Found ${#synthetic_canaries[@]} Synthetic Canary(ies) in the template"
 
-  for synhtetic_canary in "${synthetic_canaries[@]}"; do
-    if s3_key=$(yq --exit-status ".Resources.${synhtetic_canary}.Properties.Code.S3Key" "$TEMPLATE_OUT_FILE"); then
-      echo "❭ $synhtetic_canary"
+  for synthetic_canary in "${synthetic_canaries[@]}"; do
+    if s3_key=$(yq --exit-status ".Resources.${synthetic_canary}.Properties.Code.S3Key" "$TEMPLATE_OUT_FILE"); then
+      echo "❭ $synthetic_canary"
       version_id=$(aws s3api put-object \
         --bucket "$ARTIFACT_BUCKET" \
         --key "$s3_key" \
@@ -98,7 +98,7 @@ if [ -n "${SYNTHETICS_DIRECTORY}" ]; then
         --metadata "$metadata" \
         --query VersionId)
 
-      yq -i ".Resources.${synhtetic_canary}.Properties.Code.S3ObjectVersion = $version_id" "$TEMPLATE_OUT_FILE"
+      yq -i ".Resources.${synthetic_canary}.Properties.Code.S3ObjectVersion = $version_id" "$TEMPLATE_OUT_FILE"
     fi
   done
 


### PR DESCRIPTION
## Description
- prevent commit messages with quote marks like single quotes breaking upload script
- this will also prevent command injection attacks
- fix typo for synthetic_canary
- Add automated test
### Ticket number

[PSREDEV-3010]

## GitHub Action Releases

We
follow [recommended best practices](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions)
for releasing new versions of the action.

### Non-breaking Changes:

Release a new minor or patch version as appropriate. Then, update the base major version release (and any minor
versions) to point to this latest commit. For example, if the latest major release is v2, and you have added a
non-breaking feature, release v2.1.0 and point v2 to the same commit as v2.1.0.

NOTE: Dependabot does not pick up and raise PRs for `PATCH` versions (i.e. v3.8.1), please notify teams in the relevant
Slack channels.

### Breaking Changes:

Release a new major version as normal following semantic versioning.

## Checklist

- [ ] Is my change backwards compatible? **_Please include evidence_**
- [ ] I have tested this and added output to Jira
  **_Comment:_**
- [ ] Automated tests added
  **_Comment:_**
- [ ] Documentation added ([link]())
  **_Comment:_**
- [ ] Delete any new stacks created for this ticket
  **_Comment:_**

### Co-authored by


[PSREDEV-3010]: https://govukverify.atlassian.net/browse/PSREDEV-3010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ