### PR TITLE
PSREDEV-3036: Create tests for terraform upload action

### DIFF
--- a/.github/workflows/test-sam-upload-action.yaml
+++ b/.github/workflows/test-sam-upload-action.yaml
@@ -1,4 +1,4 @@
-name: Test upload action
+name: Test SAM upload action
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test-terraform-upload-action.yaml
+++ b/.github/workflows/test-terraform-upload-action.yaml
@@ -1,0 +1,129 @@
+name: Test Terraform upload action
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+concurrency:
+  group: test-terraform-upload-action-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  run-tests:
+    name: Test terraform upload action
+    environment: development
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull action code
+        uses: actions/checkout@v4
+
+      - name: Trim branch name
+        uses: govuk-one-login/github-actions/beautify-branch-name@5480cced560e896dea12c47ea33e548a4d093e65
+        id: get-branch-name
+        with:
+          length-limit: 63
+          verbose: false
+
+      - name: Create Dummy Terraform Artifact
+        id: upload-terraform-artifact
+        run: |
+          TF_DIR="../terraform"
+          mkdir -p "$TF_DIR/modules/auth_logic"
+          # 1. Create a child module in modules/auth_logic
+          cat <<EOF > "$TF_DIR/modules/auth_logic/main.tf"
+          resource "null_resource" "dependency_check" {}
+          EOF
+          # 2. Create the main.tf that uses the child module
+          cat <<EOF > "$TF_DIR/main.tf"
+          module "my_test_dependency" {
+            source = "./modules/auth_logic"
+          }
+          EOF
+          echo "tf_path=$TF_DIR" >> $GITHUB_OUTPUT
+          echo "commit_message=$(git log -1 --format=%s | tr '\n' ' ' | tr -d '"[]' | cut -c1-200 | xargs)" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Upload Terraform via Action
+        uses: ./terraform
+        id: upload-tf
+        with:
+          aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
+          artifact-bucket-name: ${{ vars.ARTIFACT_SOURCE_BUCKET }}
+          artifact-bucket-prefix: ${{ steps.get-branch-name.outputs.pretty-branch-name }}/upload-terraform-action-tests
+          working-directory: ${{ steps.upload-terraform-artifact.outputs.tf_path }}
+
+      - name: Check uploaded artifact
+        run: scripts/upload.terraform.test.sh
+        shell: bash
+        env:
+          ARTIFACT_BUCKET: ${{ vars.ARTIFACT_SOURCE_BUCKET }}
+          ARTIFACT_PREFIX: ${{ steps.get-branch-name.outputs.pretty-branch-name }}/upload-terraform-action-tests
+          COMMIT_MESSAGE: ${{ steps.upload-terraform-artifact.outputs.commit_message }}
+          ZIP_FILE: package.zip
+          VERSION: test-${{ github.sha }}
+
+  run-upload-script-tests:
+    name: Test terraform upload script
+    environment: development
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull action code
+        uses: actions/checkout@v4
+
+      - name: Trim branch name
+        uses: govuk-one-login/github-actions/beautify-branch-name@5480cced560e896dea12c47ea33e548a4d093e65
+        id: get-branch-name
+        with:
+          length-limit: 63
+          verbose: false
+
+      - name: Create Dummy Terraform Artifact
+        id: upload-terraform-artifact
+        run: |
+          TF_DIR="terraform"
+          mkdir -p "$TF_DIR/modules/auth_logic"
+          # 1. Create a child module in modules/auth_logic
+          cat <<EOF > "$TF_DIR/modules/auth_logic/main.tf"
+          resource "null_resource" "dependency_check" {}
+          EOF
+          # 2. Create the main.tf that uses the child module
+          cat <<EOF > "$TF_DIR/main.tf"
+          module "my_test_dependency" {
+            source = "./modules/auth_logic"
+          }
+          EOF
+          echo "tf_path=$TF_DIR/main.tf" >> $GITHUB_OUTPUT
+          echo "commit_message=$(git log -1 --format=%s | tr '\n' ' ' | tr -d '"[]' | cut -c1-200 | xargs)" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Assume AWS Role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: eu-west-2
+
+      - name: Run upload script
+        run: scripts/upload.terraform.sh
+        shell: bash
+        id: upload-tf
+        env:
+          ARTIFACT_BUCKET: ${{ vars.ARTIFACT_SOURCE_BUCKET }}
+          ARTIFACT_PREFIX: ${{ steps.get-branch-name.outputs.pretty-branch-name }}/upload-terraform-scripts-tests
+          WORKING_DIRECTORY: terraform
+
+      - name: Check uploaded artifact
+        run: scripts/upload.terraform.test.sh
+        shell: bash
+        env:
+          ARTIFACT_BUCKET: ${{ vars.ARTIFACT_SOURCE_BUCKET }}
+          ARTIFACT_PREFIX: ${{ steps.get-branch-name.outputs.pretty-branch-name }}/upload-terraform-scripts-tests
+          COMMIT_MESSAGE: ${{ steps.upload-terraform-artifact.outputs.commit_message }}
+          ZIP_FILE: package.zip
+          VERSION: test-${{ github.sha }}

--- a/scripts/upload.terraform.test.sh
+++ b/scripts/upload.terraform.test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source scripts/utility.test.sh
+
+: "${ARTIFACT_BUCKET:?}"
+: "${ARTIFACT_PREFIX:=""}"
+: "${COMMIT_MESSAGE:=$(git log -1 --format=%s | head -n 1 | cut -c1-200)}"
+: "${VERSION:=}"
+: "${ZIP_FILE:=package.zip}"
+
+# Overwrite the global `expected_metadata` array in `utility.test.sh` with Terraform-specific keys
+expected_metadata=(
+  [commitsha]=$GITHUB_SHA
+  [commitmessage]=$COMMIT_MESSAGE
+  [repository]=$GITHUB_REPOSITORY
+)
+
+if [[ -n "$ARTIFACT_PREFIX" ]]; then
+  s3_prefix="${ARTIFACT_PREFIX%%+(/)}/"
+else
+  s3_prefix=""
+fi
+S3_KEY="${s3_prefix}package.zip"
+S3_ZIPSUM="s3://${ARTIFACT_BUCKET}/${s3_prefix}zipsum.txt"
+
+verify-object-metadata "$S3_KEY" "Terraform Artifact"
+echo "✅ Verified metadata successfully"
+verify-terraform-zip-contents "$S3_KEY"
+echo "✅ Verified zip contents successfully"
+verify-terraform-zipsum "$S3_ZIPSUM"
+echo "✅ Verified zipsum successfully"

--- a/terraform/action.yaml
+++ b/terraform/action.yaml
@@ -12,6 +12,9 @@ inputs:
   artifact-bucket-name:
     description: The name of the artifact S3 bucket
     required: true
+  artifact-bucket-prefix:
+    description: The path at which the artifact should be placed within the S3 bucket
+    required: false
   signing-profile-name:
     description: The name of the Signing Profile
     required: false
@@ -28,8 +31,6 @@ runs:
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
-      with:
-        terraform_version: 1.14.0
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v5
@@ -44,6 +45,7 @@ runs:
       env:
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
         ARTIFACT_BUCKET: ${{ inputs.artifact-bucket-name }}
+        ARTIFACT_PREFIX: ${{ inputs.artifact-bucket-prefix }}
         SIGNING_PROFILE: ${{ inputs.signing-profile-name }}
         HEAD_MESSAGE: ${{ github.event.head_commit.message }}
         COMMIT_SHA: ${{ github.event.head_commit.id }}


### PR DESCRIPTION
## Description
This PR creates tests, which run on Pull Request, that test the Terraform upload action. The tests are based on the existing upload action test and share some functions.
The tests can also be run manually from workflow dispatch.
Both the Terraform upload action script and action workflow are tested.

Sample terraform is created to be included in the uploaded artifact for use in the tests.

Added `ARTIFACT_PREFIX` optional parameter to the Terraform upload action workflow and script so tests can uploaded to a test folder based on the branch name.

Added new functions to the shared `utility.test.sh` script to test for the following:
- The artifact (`package.zip`) has been uploaded to the test s3 bucket and the metadata matches what is expected 
- `package.zip` can be downloaded
- Checks the `service.zip` exists within `package.zip`
- Checks the `ZipSignature` file exists within `package.zip`
- Checks the  `.terraform/modules` folder exists within `package.zip`
- Checks the  `modules.json` file exists within `package.zip`
- Checks `terraform get` dependencies by verifying the dependancies are present in the `module,json` file
- Checks the `zipsum.txt` file exists in the test s3 bucket

Also, renamed `.github/workflows/test-action.yaml` to `.github/workflows/test-sam-upload-action.yaml` for consistency

Tested successfully - https://github.com/govuk-one-login/devplatform-upload-action/actions/runs/21293573926/job/61293403666
Also tested using `devplatform-demo-infra` repo as it uses the Terraform upload action - https://github.com/govuk-one-login/devplatform-demo-infra/actions/runs/21355189318

### Ticket number

[PSREDEV-3036]

## GitHub Action Releases

We follow [recommended best practices](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions) for releasing new versions of the action.

### Non-breaking Changes:

Release a new minor or patch version as appropriate. Then, update the base major version release (and any minor
versions) to point to this latest commit. For example, if the latest major release is v2, and you have added a
non-breaking feature, release v2.1.0 and point v2 to the same commit as v2.1.0.

NOTE: Dependabot does not pick up and raise PRs for `PATCH` versions (i.e. v3.8.1), please notify teams in the relevant
Slack channels.

### Breaking Changes:

Release a new major version as normal following semantic versioning.

## Checklist

- [X] Is my change backwards compatible? **_Please include evidence_**
- [X] I have tested this and added output to Jira
  Links above to successful test run
- [X] Automated tests added
- [ ] Documentation added ([link]())
  N/A
- [ ] Delete any new stacks created for this ticket
  N/A

### Co-authored by


[PSREDEV-3036]: https://govukverify.atlassian.net/browse/PSREDEV-3036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ