### PR TITLE
NOJIRA: Adding skip canaries as an option to skip canaries

### DIFF
--- a/scripts/upload.sam.sh
+++ b/scripts/upload.sam.sh
@@ -43,7 +43,7 @@ sam package \
 echo "::endgroup::"
 echo "::group::Gathering release metadata"
 
-[[ $COMMIT_MESSAGES =~ \[(skip canary|no canary|canary skip)\] ]] && skip_canary=1
+[[ $COMMIT_MESSAGES =~ \[(skip canary|skip canaries|no canary|canary skip)\] ]] && skip_canary=1
 [[ $COMMIT_MESSAGES =~ \[(close circuit breaker|end circuit breaker)\] ]] && close_circuit_breaker=1
 
 release_metadata=(


### PR DESCRIPTION
# Description

Adding `skip canaries` as part of the string search to set `skip_canary` in the upload metadata. 

This is because i keep on wanting to write this instead instead of `skip canary` 


Tested in `bash`: 

```
❯ COMMIT_MESSAGES="[skip canary]"; [[ $COMMIT_MESSAGES =~ \[(skip canary|no canary|canary skip)\] ]]; echo $?
0

❯ COMMIT_MESSAGES="[skip canaries]"; [[ $COMMIT_MESSAGES =~ \[(skip canary|no canary|canary skip)\] ]]; echo $?
1

❯ COMMIT_MESSAGES="[skip canaries]"; [[ $COMMIT_MESSAGES =~ \[(skip canary|skip canaries|no canary|canary skip)\] ]]; echo $?
0
```

`0` is a match :) 

## Checklist

- [X] Is my change backwards compatible?
- [ ] I have tested this and added output to Jira
  **_Comment:_**
- [ ] Automated tests added
  **_Comment:_**
- [ ] Documentation added ([link]())
  **_Comment:_**
- [ ] Delete any new stacks created for this ticket
  **_Comment:_**

### Co-authored by
