### PR TITLE
PSREDEV-3478: Package terraform module dependencies 

### DIFF
--- a/.github/workflows/test-terraform-upload-action.yaml
+++ b/.github/workflows/test-terraform-upload-action.yaml
@@ -54,7 +54,7 @@ jobs:
           aws-role-arn: ${{ vars.AWS_ROLE_ARN }}
           artifact-bucket-name: ${{ vars.ARTIFACT_SOURCE_BUCKET }}
           artifact-bucket-prefix: ${{ steps.get-branch-name.outputs.pretty-branch-name }}/upload-terraform-action-tests
-          working-directory: ${{ steps.upload-terraform-artifact.outputs.tf_path }}
+          source-path: ${{ steps.upload-terraform-artifact.outputs.tf_path }}
 
       - name: Check uploaded artifact
         run: scripts/upload.terraform.test.sh
@@ -116,7 +116,9 @@ jobs:
         env:
           ARTIFACT_BUCKET: ${{ vars.ARTIFACT_SOURCE_BUCKET }}
           ARTIFACT_PREFIX: ${{ steps.get-branch-name.outputs.pretty-branch-name }}/upload-terraform-scripts-tests
-          WORKING_DIRECTORY: terraform
+          GITHUB_TOKEN: dummy-github-token-1234
+          TF_MODULE_PATH: terraform
+          SOURCE_PATH: terraform
 
       - name: Check uploaded artifact
         run: scripts/upload.terraform.test.sh
@@ -127,3 +129,4 @@ jobs:
           COMMIT_MESSAGE: ${{ steps.upload-terraform-artifact.outputs.commit_message }}
           ZIP_FILE: package.zip
           VERSION: test-${{ github.sha }}
+          GITHUB_TOKEN: dummy-github-token-1234

--- a/scripts/upload.terraform.sh
+++ b/scripts/upload.terraform.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 shopt -s extglob nocasematch
 
-: "${WORKING_DIRECTORY:?}"
+: "${SOURCE_PATH:?}"
 : "${ARTIFACT_BUCKET:?}"
 : "${ARTIFACT_PREFIX:=""}"
 : "${SIGNING_PROFILE:=""}"
@@ -10,22 +10,38 @@ shopt -s extglob nocasematch
 : "${COMMIT_MESSAGES:=}"
 : "${COMMIT_SHA:=$(git rev-parse HEAD)}"
 : "${GITHUB_REPOSITORY:?}"
+: "${GITHUB_TOKEN:=}"
+: "${TF_MODULE_PATH:=}"
 
 [[ ${ARTIFACT_PREFIX:-} ]] && s3_prefix=${ARTIFACT_PREFIX%%+(/)}/
 
-cd "$GITHUB_WORKSPACE"
-if [ ! -d "$WORKING_DIRECTORY" ]; then
-  echo "Error: Working directory $WORKING_DIRECTORY not found." >&2
-  exit 1
+function check_directory_exists() {
+  local directory=$1
+  if ! [[ -d $directory ]]; then
+    echo "Error: Directory $directory not found" >&2
+    exit 1
+  fi
+}
+
+echo "::group::Downloading Terraform module dependencies"
+echo "» Checking Terraform root directory exists"
+
+if [[ $GITHUB_TOKEN ]]; then
+  git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/govuk-one-login".insteadOf "ssh://git@github.com/govuk-one-login"
 fi
 
-cd "$WORKING_DIRECTORY"
-terraform get
+check_directory_exists "$TF_MODULE_PATH"
+terraform -chdir="${TF_MODULE_PATH}" get
+
+echo "» Terraform modules downloaded"
+echo "::endgroup::"
+
+echo "» Checking source path exists"
+check_directory_exists "$SOURCE_PATH"
 
 SERVICE_ZIP_NAME="service.zip"
 SERVICE_ZIP_PATH="$GITHUB_WORKSPACE/$SERVICE_ZIP_NAME"
-cd "$GITHUB_WORKSPACE"
-zip -r "$SERVICE_ZIP_PATH" "$WORKING_DIRECTORY"
+zip -r "$SERVICE_ZIP_PATH" "$SOURCE_PATH"
 
 ZIPSUM_FILE="zipsum.txt"
 SIGNATURE_FILE="ZipSignature"

--- a/scripts/upload.terraform.test.sh
+++ b/scripts/upload.terraform.test.sh
@@ -6,6 +6,7 @@ source scripts/utility.test.sh
 : "${ARTIFACT_BUCKET:?}"
 : "${ARTIFACT_PREFIX:=""}"
 : "${COMMIT_MESSAGE:=$(git log -1 --format=%s | head -n 1 | cut -c1-50)}"
+: "${GITHUB_TOKEN:=}"
 : "${VERSION:=}"
 : "${ZIP_FILE:=package.zip}"
 
@@ -31,3 +32,8 @@ verify-terraform-zip-contents "$S3_KEY"
 echo "✅ Verified zip contents successfully"
 verify-terraform-zipsum "$S3_ZIPSUM"
 echo "✅ Verified zipsum successfully"
+
+if [[ $GITHUB_TOKEN ]]; then
+  verify_git_auth_config "$GITHUB_TOKEN"
+  echo "✅ Verified authentication with GitHub token is configured successfully"
+fi

--- a/scripts/utility.test.sh
+++ b/scripts/utility.test.sh
@@ -170,3 +170,17 @@ function verify-terraform-zipsum() {
     exit 1
   fi
 }
+
+function verify_git_auth_config() {
+  local token=$1
+  local expected_config="https://x-access-token:${token}@github.com/govuk-one-login"
+  local actual_config
+  actual_config=$(git config --global --get url."${expected_config}".insteadOf 2> /dev/null || true)
+
+  if [[ $actual_config == "ssh://git@github.com/govuk-one-login" ]]; then
+    echo "✅ Success: GitHub App authenticaton configured"
+  else
+    echo "❌ Error: GitHub App authentication configured incorrectly"
+    exit 1
+  fi
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -12,30 +12,92 @@ It adds the following metadata to the S3 object:
 | `skipapproval`  | Flag to indicate if the requirement for manual approval should be overridden via the [auto-approve-all] or [skip-appproval] magic flags |
 | `skipapprovalenvs` | Comma delimited list of environments where the requirement for manual approval should be overridden via the [auto-approve-_ENV_] or [skip-appproval-_ENV_] magic flags (where _ENV_ is a the name of an environment eg `dev`, `production`) |
 
-## Action Inputs
-
-| Input | Required |Description | Example |
-|----------|----------|----------|----------|
-| artifact-bucket-name   | true     | The name of the artifact S3 bucket | artifact-bucket-1234 |
-| artifact-bucket-prefix | false     | The prefix of the artifact S3 bucket | test-folder |
-| signing-profile-name   | false     | The name of the Signing Profile in AWS | signing-profile-1234 |
-| aws-region             | false    | The name of the region to use when authenticating to AWS | eu-west-2 |
-| aws-role-arn           | false    | The ARN of the AWS to assume before uploading the artifact |arn:aws:iam::123456789000:role/role-name |
-| working-directory      | false    | The directory containing terraform | ./terraform |
 ## Usage Example
 
 Pull in the action in your workflow as below, making sure to specify the release version you require.
 
 ```yaml
 - name: Publish Terraform Artifact
-  uses: govuk-one-login/devplatform-upload-action/terraform@<version-number>
+  uses: govuk-one-login/devplatform-upload-action/terraform@<SHA>
   with:
-    working-directory: './terraform'
+    source-path: './terraform'
+    terraform-module-path: './terraform/stacks/base-stacks'
     aws-role-arn: ${{ vars.SECURE_INFRA_PIPELINE_ROLE }}
     artifact-bucket-name: ${{ vars.SECURE_INFRA_SOURCE_BUCKET }}
     signing-profile-name: ${{ vars.SECURE_INFRA_ZIP_SIGNING_KEY }}
     aws-region: 'eu-west-2'
 ```
+
+### source-path vs terraform-module-path
+
+`source-path` input is the path to the directory to be packaged and uploaded. `terraform-module-path` should be used when your Terraform module is not located directly in `source-path`.
+This distinguishment is needed because the action will always attempt to download Terraform modules dependencies. The location of your Terraform module must be configured to correctly identify dependencies.
+
+For example:
+
+```
+my-repository
+├── terraform
+    ├── main.tf
+    ├── outputs.tf
+    ├── locals.tf
+    └── (...)
+```
+
+For the repository structure above, Terraform module files are located directly in the `terraform` directory. In this case, user should set `source-path=terraform`. `terraform-module-path` can be left unset.
+
+```
+my-repository
+└── terraform
+   └── stacks
+       ├── base-stacks
+       │   ├── main.tf
+       │   ├── outputs.tf
+       │   ├── locals.tf
+       │   └── (...)
+       └── env
+            ├── dev.tfvars
+            ├── build.tfvars
+            └── (...)
+```
+
+For the case above, Terraform module files are located in a subdirectory of `terraform`. Given configuration files like `.tfvars` are located in a different subdirectory, the user will need to package the `terraform` directory as a whole. In this case, the user should set `source-path=terraform` and `terraform-module-path=terraform/stacks/base-stacks`.
+
+## Features
+
+### Download and package Terraform modules
+
+If your Terraform configuration uses modules stored in a separate private repository, you will need to pull and package them with your code. This is because the infra pipeline currently does not support authenticating to GitHub. The recommended way to do this is to have your workflow authenticate using a GitHub App with read access to your repositories.
+
+The example below shows a workflow that generates a token from a GitHub App with read access to `ipv-terraform-modules` repository. The Github token is passed to the action using `github-token` input. In addition, if your Terraform code lives in a different path to `working-directory`, provide a `terraform-root` path.
+
+```yaml
+steps:
+  - uses: actions/create-github-app-token@<SHA>
+    id: app-token
+    with:
+      app-id: ${{ secrets.INFRAPIPELINE_CLIENTID }}
+      private-key: ${{ secrets.INFRAPIPELINE_PEMKEY }}
+      repositories: |
+        ipv-terraform-modules
+
+  - name: Publish Terraform Artifact
+    uses: govuk-one-login/devplatform-upload-action/terraform@<SHA>
+    with:
+      source-path: './terraform'
+      terraform-module-path: './terraform/stacks/base-stacks'
+      aws-role-arn: ${{ vars.SECURE_INFRA_PIPELINE_ROLE }}
+      artifact-bucket-name: ${{ vars.SECURE_INFRA_SOURCE_BUCKET }}
+      siging-profile-name: ${{ vars.SECURE_INFRA_ZIP_SIGNING_KEY }}
+      github-token: ${{ steps.app-token.outputs.token }}
+      aws-region: 'eu-west-2'
+```
+
+Alternatively, you can set up your own workflow steps to fetch module dependencies before running devplatform-upload-action/terraform.
+Module dependencies must be downloaded to the same directory as your Terraform code and located in a `.terraform` directory.
+`terraform get` command can be used for this, follow [documentation](https://developer.hashicorp.com/terraform/cli/commands/get) for guidance.
+
+For more information on GitHub apps usage, visit the [gds-way documentation page](https://gds-way.digital.cabinet-office.gov.uk/standards/source-code/using-github-actions.html#authorizing-github-actions)
 
 ## Requirements
 

--- a/terraform/action.yaml
+++ b/terraform/action.yaml
@@ -1,27 +1,33 @@
 name: Terraform Artifact Publisher
-description: "Packages, signs and uploads Terraform configurations to S3 for secure infra pipelines."
+description: Packages, signs and uploads Terraform configurations to S3 for secure infra pipelines.
 
 inputs:
   aws-role-arn:
-    description: The ARN of the AWS role to assume
+    description: The ARN of the AWS role to assume. Available output from infrastructre pipeline stack.
     required: false
   aws-region:
     description: The AWS region to use
     required: false
     default: eu-west-2
   artifact-bucket-name:
-    description: The name of the artifact S3 bucket
+    description: The name of the artifact S3 bucket. Available output from infrastructre pipeline stack.
     required: true
   artifact-bucket-prefix:
     description: The path at which the artifact should be placed within the S3 bucket
     required: false
   signing-profile-name:
-    description: The name of the Signing Profile
+    description: The ARN of the KMS key to sign artifact package. Available output from infrastructre pipeline stack.
     required: false
-  working-directory:
-    description: The working directory containing terraform
+  source-path:
+    description: Path to the directory containing Terraform configuration files to package, sign and upload.
     required: false
     default: ./terraform
+  terraform-module-path:
+    description: Subdirectory within source-path that contains the Terraform module to be deployed. Defaults to source-path.
+    required: false
+  github-token:
+    description: The token to authenticate to the GitHub API used when downloading Terraform modules from private One Login repositories.
+    required: false
 
 runs:
   using: composite
@@ -43,10 +49,12 @@ runs:
       shell: bash
       run: ${{ github.action_path }}/../scripts/upload.terraform.sh
       env:
-        WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        SOURCE_PATH: ${{ inputs.source-path }}
         ARTIFACT_BUCKET: ${{ inputs.artifact-bucket-name }}
         ARTIFACT_PREFIX: ${{ inputs.artifact-bucket-prefix }}
         SIGNING_PROFILE: ${{ inputs.signing-profile-name }}
         HEAD_MESSAGE: ${{ github.event.head_commit.message }}
         COMMIT_MESSAGES: ${{ join(github.event.commits.*.message, ' | ') }}
         COMMIT_SHA: ${{ github.event.head_commit.id }}
+        TF_MODULE_PATH: ${{ inputs.terraform-module-path || inputs.source-path }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/terraform/action.yaml
+++ b/terraform/action.yaml
@@ -15,6 +15,11 @@ inputs:
   artifact-bucket-prefix:
     description: The path at which the artifact should be placed within the S3 bucket
     required: false
+  checkout-repo:
+    description: Check out the repo as the first step of the action. Defaults to "true".
+    type: boolean
+    required: false
+    default: true
   signing-profile-name:
     description: The ARN of the KMS key to sign artifact package. Available output from infrastructre pipeline stack.
     required: false
@@ -33,6 +38,7 @@ runs:
   using: composite
   steps:
     - name: Checkout Repository
+      if: ${{ inputs.checkout-repo == 'true' }}
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Setup Terraform


### PR DESCRIPTION
## Description
- Added optional feature that adds a step to download Terraform modules stored in a private repository. terraform-root input can be specified in case Terraform code is not located in working-direcotry. github-token must be provided for authentication.
- The use of command `terraform get` will download modules so it can be packaged with terraform code. When infra-pipeline initiates terraform, it will skip downloading already packaged modules, avoiding the need to authenticate to GitHub from AWS.
- This feature avoids the use of GitHub apps for authentication within AWS, as this design has not yet been formalised by the program

### Ticket number

[PSREDEV-3324]

### Tests

- Infra pipeline will deploy modules when using action download modules feature
<img width="1425" height="593" alt="Screenshot 2026-05-29 at 08 41 06" src="https://github.com/user-attachments/assets/b90ff929-e3b0-4e78-b30c-870ebe209d21" />


- Infra pipeline will deploy modules when modules are downloaded outside of this action
<img width="1430" height="496" alt="Screenshot 2026-05-29 at 09 05 31" src="https://github.com/user-attachments/assets/e6453aae-e0d2-4884-ba46-d83bbacaa7f7" />


- Action enforce terraform get for all cases, including when no modules are present and github token is not given
<img width="787" height="55" alt="Screenshot 2026-05-29 at 08 50 42" src="https://github.com/user-attachments/assets/6e0322cb-806f-4b03-9aae-5337c954a8ad" />





- Action will throw an error when terraform-root is not a valid directory path
<img width="508" height="49" alt="Screenshot 2026-05-20 at 09 23 34" src="https://github.com/user-attachments/assets/df829277-accb-42df-b38a-08b8b9c86bc3" />




[PSREDEV-3324]: https://govukverify.atlassian.net/browse/PSREDEV-3324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ