### PR TITLE
Deprecated signing profile name and added kms key

### DIFF
--- a/scripts/upload.terraform.sh
+++ b/scripts/upload.terraform.sh
@@ -5,7 +5,7 @@ shopt -s extglob nocasematch
 : "${SOURCE_PATH:?}"
 : "${ARTIFACT_BUCKET:?}"
 : "${ARTIFACT_PREFIX:=""}"
-: "${SIGNING_PROFILE:=""}"
+: "${SIGNING_KMS_KEY_ARN:=""}"
 : "${HEAD_MESSAGE:=$(git log -1 --format=%s)}"
 : "${COMMIT_MESSAGES:=}"
 : "${COMMIT_SHA:=$(git rev-parse HEAD)}"
@@ -48,16 +48,16 @@ SIGNATURE_FILE="ZipSignature"
 PACKAGE_FILE="package.zip"
 md5sum "$SERVICE_ZIP_PATH" | cut -c -32 > $ZIPSUM_FILE
 
-if [[ -n "$SIGNING_PROFILE" ]]; then
+if [[ -n "$SIGNING_KMS_KEY_ARN" ]]; then
   aws kms sign \
-    --key-id "$SIGNING_PROFILE" \
+    --key-id "$SIGNING_KMS_KEY_ARN" \
     --message fileb://"$ZIPSUM_FILE" \
     --signing-algorithm RSASSA_PSS_SHA_256 \
     --message-type RAW \
     --output text \
     --query Signature | base64 --decode > $SIGNATURE_FILE
 else
-  echo "No SIGNING_PROFILE provided, skipping signing step."
+  echo "No SIGNING_KMS_KEY_ARN provided, skipping signing step."
   touch $SIGNATURE_FILE
 fi
 zip -r $PACKAGE_FILE "$SERVICE_ZIP_NAME" "$SIGNATURE_FILE"

--- a/terraform/action.yaml
+++ b/terraform/action.yaml
@@ -20,9 +20,11 @@ inputs:
     type: boolean
     required: false
     default: true
-  signing-profile-name:
-    description: The ARN of the KMS key to sign artifact package. Available output from infrastructre pipeline stack.
+  signing-kms-key-arn:
+    description: The ARN of the Signing KMS Key. This will be used to sign the artifact. If not provided, the artifact will be uploaded without signing.
     required: false
+  signing-profile-name:
+    description: The name of the Signing Profile. This has been deprecated and will be removed in a future release. Please use 'signing-kms-key-arn' instead.
   source-path:
     description: Path to the directory containing Terraform configuration files to package, sign and upload.
     required: false
@@ -51,6 +53,11 @@ runs:
         aws-region: ${{ inputs.aws-region }}
         role-session-name: github-actions-${{ github.sha }}
 
+    - name: Deprecated Signing Profile Check
+      if: ${{ inputs.signing-profile-name }}
+      shell: bash
+      run: |
+        echo "::warning::⚠️ 'signing-profile-name' is deprecated and will be removed in a future release! Please use 'signing-kms-key-arn' instead."
     - name: Execute Packaging, Signing, and Upload
       shell: bash
       run: ${{ github.action_path }}/../scripts/upload.terraform.sh
@@ -58,7 +65,7 @@ runs:
         SOURCE_PATH: ${{ inputs.source-path }}
         ARTIFACT_BUCKET: ${{ inputs.artifact-bucket-name }}
         ARTIFACT_PREFIX: ${{ inputs.artifact-bucket-prefix }}
-        SIGNING_PROFILE: ${{ inputs.signing-profile-name }}
+        SIGNING_KMS_KEY_ARN: ${{ inputs.signing-kms-key-arn || inputs.signing-profile-name }}
         HEAD_MESSAGE: ${{ github.event.head_commit.message }}
         COMMIT_MESSAGES: ${{ join(github.event.commits.*.message, ' | ') }}
         COMMIT_SHA: ${{ github.event.head_commit.id }}


### PR DESCRIPTION
## Description
The input parameter signing-profile-name is now deprecated although it can still be used (a warning will be issued). The signing-kms-key-arn input parameter is the preferred mechanism and documentation updated to reflect this. 

### Ticket number

[PSREDEV-3401]

## GitHub Action Releases

We
follow [recommended best practices](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions)
for releasing new versions of the action.

### Non-breaking Changes:

Release a new minor or patch version as appropriate. Then, update the base major version release (and any minor
versions) to point to this latest commit. For example, if the latest major release is v2, and you have added a
non-breaking feature, release v2.1.0 and point v2 to the same commit as v2.1.0.

NOTE: Dependabot does not pick up and raise PRs for `PATCH` versions (i.e. v3.8.1), please notify teams in the relevant
Slack channels.

### Breaking Changes:

Release a new major version as normal following semantic versioning.

## Checklist

- [X] Is my change backwards compatible? **_Please include evidence_**
- [X] I have tested this and added output to Jira
  **_Comment:_**
[Link](https://govukverify.atlassian.net/browse/PSREDEV-3506?focusedCommentId=319259)
- [ ] Automated tests added
  **_Comment:_**
- [ ] Documentation added ([link]())
  **_Comment:_**
- [ ] Delete any new stacks created for this ticket
  **_Comment:_**

### Co-authored by
Ciaran Grant

[PSREDEV-3401]: https://govukverify.atlassian.net/browse/PSREDEV-3401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ